### PR TITLE
Text improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Hylia version 0.1.2 features:
 🎨 Customisable design tokens to make it your own  
 🌍 Customisable global data and navigation  
 📂 Tags and tag archives  
-✅ Progressively enhanced, semantic and accessible    
-🎈 _Super_ lightweight front-end   
+✅ Progressively enhanced, semantic and accessible  
+🎈 _Super_ lightweight front-end  
 🚰 Sass powered CSS system with utility class generator  
 ⚙️  Service worker that caches pages so people can read your articles offline  
 🚀 An RSS feed for your posts
 
-## Roadmap 
+## Roadmap
 
 💬 [Netlify Forms](https://www.netlify.com/docs/form-handling/) powered comments  
 💡 Dark/Light mode toggle  
@@ -45,7 +45,7 @@ You can [deploy Hylia to Netlify with one click](https://app.netlify.com/start/d
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/andybelldesign/hylia)
 
-I recorded a quick start video of me deploying Hylia to Netlify and getting the CMS set up. [Check it out here](https://youtu.be/0hM_0BH-Y_A). 
+I recorded a quick start video of me deploying Hylia to Netlify and getting the CMS set up. [Check it out here](https://youtu.be/0hM_0BH-Y_A).
 
 
 ### Method two: Clone / Fork
@@ -53,11 +53,11 @@ I recorded a quick start video of me deploying Hylia to Netlify and getting the 
 1. Clone or fork this repo: `git clone https://github.com/andybelldesign/hylia`
 2. `cd` into the project directory and run `npm install`
 3. Once all the dependencies are installed run `npm start`
-4. Open your browser at `http://localhost:8080` and away you go! 
+4. Open your browser at `http://localhost:8080` and away you go!
 
-## Terminal commands 
+## Terminal commands
 
-### Serve the site locally 
+### Serve the site locally
 
 ```bash
 npm start
@@ -69,7 +69,7 @@ npm start
 npm run production
 ```
 
-### Compile Sass 
+### Compile Sass
 
 ```bash
 npm run sass:process
@@ -93,24 +93,24 @@ In short, though:
 - Once you’ve enabled identity, click “Invite Users”
 - Check the invite link in your inbox and click the link in the email that’s sent to you
 - Set a password in the popup box
-- Go to `/admin` on your site and login 
+- Go to `/admin` on your site and login
 - You’re in and ready to edit your content!
 
-## Design Tokens and Styleguide 
+## Design Tokens and Styleguide
 
 ### Design Tokens
 
-Although Hylia has a pretty simple design, you can configure the core design tokens that control the colours, size ratio and fonts. 
+Although Hylia has a pretty simple design, you can configure the core design tokens that control the colours, size ratio and fonts.
 
-*** 
+***
 
 **Note**: *Credit must be given to the hard work [Jina Anne](https://aycl.uie.com/virtual_seminars/design_tokens_scaling_design_with_a_single_source_of_truth) did in order for the concept of design tokens to even exist. You should watch [this video](https://www.youtube.com/watch?v=wDBEc3dJJV8), then [read this article](https://the-pastry-box-project.net/jina-bolton/2015-march-28) and then sign up for [this course](https://twitter.com/jina) to expand your knowledge.*
 
 ***
 
-To change the design tokens in the CMS, find the “Globals” in the sidebar then in the presented options, select “Theme Settings”. 
+To change the design tokens in the CMS, find the “Globals” in the sidebar then in the presented options, select “Theme Settings”.
 
-To change the design tokens directly, edit [`_src/data/tokens.json`](https://github.com/andybelldesign/hylia/blob/master/src/_data/tokens.json). 
+To change the design tokens directly, edit [`_src/data/tokens.json`](https://github.com/andybelldesign/hylia/blob/master/src/_data/tokens.json).
 
 The tokens are converted into maps that the Sass uses to compile the front-end CSS, so make sure that you maintain the correct structure of `tokens.json`.
 
@@ -133,14 +133,14 @@ Before Sass is compiled, a `_tokens.scss` file is generated from the [design tok
 Key elements:
 
 - `$stalfos-size-scale`: A token driven size scale which by default, is a “Major Third” scale
-- `$stalfos-colors`: A token driven map of colours 
+- `$stalfos-colors`: A token driven map of colours
 - `$stalfos-util-prefix`: All pre-built, framework utilities will have this prefix. Example: the wrapper utility is '.sf-wrapper' because the default prefix is 'sf-'
 - `$metrics`: Various misc metrics to use around the site
 - `$stalfos-config`: This powers everything from utility class generation to breakpoints to enabling/disabling pre-built components/utilities
 
 ### How to create a new utility class with the generator
 
-The utility class generator lets you generate whatever you want, with no opinions on class name or properties affected. 
+The utility class generator lets you generate whatever you want, with no opinions on class name or properties affected.
 
 To add a new class, add another item to the exists `$stalfos-config` map. This example adds a utility for floating elements.
 
@@ -155,7 +155,7 @@ To add a new class, add another item to the exists `$stalfos-config` map. This e
 )
 ```
 
-The `output` is set to `responsive` which means every breakpoint will generate a prefixed class for itself. If you only wanted elements to float left in the `md` breakpoint, you’d now be able to add a class of `md:float-left` to your HTML elements. 
+The `output` is set to `responsive` which means every breakpoint will generate a prefixed class for itself. If you only wanted elements to float left in the `md` breakpoint, you’d now be able to add a class of `md:float-left` to your HTML elements.
 
 If you only want standard utility classes generating, set the `output` to `standard`.
 
@@ -198,14 +198,14 @@ The basic CMS setup allows you to edit the following:
 - **Navigation**: Edit your primary navigation items
 - **Theme**: Edit the design tokens that power the site’s theme
 
-## Get involved 
+## Get involved
 
 This project is _super_ early and feedback is very much welcome. In order to keep things running smooth, please consult the [contribution guide and code of conduct](https://github.com/andybelldesign/hylia/blob/master/contributing.md).
 
 The stuff that I need the most help with is:
 
 - Documentation
-- Webmentions 
+- Webmentions
 - Performance
 
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ This project is _super_ early and feedback is very much welcome. In order to kee
 The stuff that I need the most help with is:
 
 - Documentation
-- Webmentions
+- [Webmentions](https://www.w3.org/TR/webmention/)
 - Performance
 
 

--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -6,7 +6,7 @@
       "external": false
     },
     {
-      "text": "Github",
+      "text": "GitHub",
       "url": "https://github.com/andybelldesign/hylia",
       "external": true
     },

--- a/src/posts/a-post-with-figures-and-video.md
+++ b/src/posts/a-post-with-figures-and-video.md
@@ -16,7 +16,7 @@ You can also add videos to posts from YouTube or Vimeo (or wherever, really) and
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/_38JDGnr0vA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Finally, how about a `<blockquote>`? 
+Finally, how about a `<blockquote>`?
 
 > Quotes will take a slightly different style to normal body text and look fancy.
 

--- a/src/posts/a-simple-post.md
+++ b/src/posts/a-simple-post.md
@@ -8,7 +8,7 @@ tags:
 ---
 A simple post to demonstrate how a normal blog post looks on Hylia. Content is all set in the “Body” field as markdown and Eleventy transforms it into a proper HTML post. You can also edit the markdown file directly if you prefer not to use the CMS.
 
-How about a `<blockquote>`? 
+How about a `<blockquote>`?
 
 > Maecenas faucibus mollis interdum. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Aenean lacinia bibendum nulla sed consectetur. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit libero, a pharetra augue.
 

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -9,7 +9,7 @@
 }
 
 body {
-  // Strip the unit off the size ratioto generate a line height
+  // Strip the unit off the size ratio to generate a line height
   $line-height: get-size(600);
   line-height: $line-height / ($line-height * 0 + 1);
 


### PR DESCRIPTION
Various smaller improvements.


# Changes

## docs(scss): fix spelling spelling mistake

- Fix spelling spelling mistake
  - `size ratioto` --> `size ratio to`

## fix(navigation): change text from `Github` to `GitHub` for consistency

- Change navigation link text from `Github` to `GitHub`
  - Official brand name for improved consistency

## docs: add link to Webmention specs (W3C Recommendation 12 January 2017)

- Add link to Webmention specs (W3C Recommendation 12 January 2017)

## docs: improvements to Markdown syntax based on markdownlint

- Remove trailing whitespace
- Fix markdownlint warnings
  - MD009/no-trailing-spaces: Trailing spaces