### PR TITLE
Overflow Bug: Mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hylia",
-  "version": "1.0.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -22,6 +22,10 @@ body {
   background-color: var(--color-bg);
 }
 
+main {
+  overflow: hidden;
+}
+
 ::selection {
   color: var(--color-selection-text);
   background-color: var(--color-selection-bg);

--- a/src/scss/components/_post.scss
+++ b/src/scss/components/_post.scss
@@ -13,7 +13,7 @@
     h2,
     h3 {
       position: relative;
-      display: flex;
+      /*display: flex;*/
 
       @include apply-utility('leading', 'tight');
     }
@@ -82,9 +82,10 @@
     .video-player {
       width: 100vw;
       max-width: map-get($metrics, 'wrap-max-width');
-      margin-left: 50%;
-      transform: translateX(-50%);
+      margin-left: 50%; /*changing this value to 47% removes the horizontal scrollbar once the viewport is < 930px */
+      transform: translateX(-50%); /* changing this value to 49% allows for the suggestion above to also eliminate the horizontal scroll. */
       position: relative;
+      overflow: hidden;
     }
 
     figure img,

--- a/src/scss/components/_post.scss
+++ b/src/scss/components/_post.scss
@@ -85,7 +85,6 @@
       margin-left: 50%; /*changing this value to 47% removes the horizontal scrollbar once the viewport is < 930px */
       transform: translateX(-50%); /* changing this value to 49% allows for the suggestion above to also eliminate the horizontal scroll. */
       position: relative;
-      overflow: hidden;
     }
 
     figure img,

--- a/src/scss/components/_syntax-highlighting.scss
+++ b/src/scss/components/_syntax-highlighting.scss
@@ -10,7 +10,16 @@ pre[class*='language-'] {
   background: none;
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   text-align: left;
-  white-space: pre;
+  /* 
+  this suggestion provided by Chris Coyier on CSS-Tricks:
+  https://css-tricks.com/snippets/css/make-pre-text-wrap/
+  */
+  white-space: pre-wrap;       /* css-3 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  
   word-spacing: normal;
   word-break: normal;
   word-wrap: normal;


### PR DESCRIPTION
- Removing display flex from `.post__body h2, .post__body h3` will allow the headings to wrap to the next line instead of running outside of the viewport.
<img width="335" alt="Screenshot 2019-06-21 17 28 41" src="https://user-images.githubusercontent.com/6185899/59952410-0c845280-944a-11e9-9eb0-99eaeafdceaa.png">

- Setting `white-space: pre` to `white-space: pre-wrap` will allow for the code examples to wrap to the next line instead of outside of the viewport. [This suggestion comes from an post Chris Coyier made on CSS-Tricks for getting pre tags to wrap better.](https://css-tricks.com/snippets/css/make-pre-text-wrap/)
<img width="322" alt="Screenshot 2019-06-21 17 31 19" src="https://user-images.githubusercontent.com/6185899/59952502-6d138f80-944a-11e9-9471-6b47611410d5.png">

I don't think the phones I tested on are as small as the one reported in #36  but I did test on the following mobile devices and wasn't able to horizontally scroll at all:
Safari and Firefox on an iPhone XS , Chrome and Firefox on a Pixel 2 XL

- There is however a tiny bit of horizontal scrolling that is present after applying the fixes listed above in the following desktop browsers:
Safari, Chrome, Firefox 

Applying `overflow: hidden` to the `main` tag hides this tiny bit of overflow that is being caused by the full-bleed utility. 

Let me know if you have any thoughts on these suggestions!