### PR TITLE
Make npm scripts work on windows cmd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hylia",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1605,6 +1605,16 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "chokidar-cli": "^1.2.2",
+    "cross-env": "^5.2.0",
     "make-dir-cli": "^2.0.0",
     "rollup": "^1.16.1",
     "rollup-plugin-commonjs": "^10.0.0",
@@ -30,7 +31,7 @@
     "cms:precompile": "make-dir dist/admin && nunjucks-precompile src/_includes > dist/admin/templates.js -i '\\.(njk|css|svg)$'",
     "cms:bundle": "rollup --config",
     "start": "concurrently 'npm run sass:process -- --watch' 'npm run cms:bundle -- --watch' 'chokidar \"src/_includes/**\" -c \"npm run cms:precompile\"' 'npm run serve'",
-    "serve": "ELEVENTY_ENV=development npx eleventy --serve",
+    "serve": "cross-env ELEVENTY_ENV=development npx eleventy --serve",
     "production": "npm run sass:process && npm run cms:precompile && npm run cms:bundle && npx eleventy"
   },
   "repository": {


### PR DESCRIPTION
Adds cross-env package to dev so that npm scripts work on a windows command line.... but seriously use WSL... but if you can't... I got ya 😉.

Fixes: #30 