### PR TITLE
feat: support scheduled and draft posts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -31,15 +31,23 @@ module.exports = function(config) {
   config.addPassthroughCopy('src/images');
   config.addPassthroughCopy('src/admin/config.yml');
   config.addPassthroughCopy('src/admin/previews.js');
-  config.addPassthroughCopy('node_modules/nunjucks/browser/nunjucks-slim.js')
+  config.addPassthroughCopy('node_modules/nunjucks/browser/nunjucks-slim.js');
+
+  const now = new Date();
 
   // Custom collections
+  const livePosts = post => post.date <= now && !post.data.draft;
   config.addCollection('posts', collection => {
-    return [...collection.getFilteredByGlob('./src/posts/*.md')].reverse();
+    return collection
+      .getFilteredByGlob('./src/posts/*.md')
+      .filter(livePosts)
+      .reverse();
   });
 
   config.addCollection('postFeed', collection => {
-    return [...collection.getFilteredByGlob('./src/posts/*.md')]
+    return collection
+      .getFilteredByGlob('./src/posts/*.md')
+      .filter(livePosts)
       .reverse()
       .slice(0, site.maxPostsPerPage);
   });

--- a/src/posts/a-schduled-post.md
+++ b/src/posts/a-schduled-post.md
@@ -1,0 +1,33 @@
+---
+title: A scheduled post
+date: '2022-06-18'
+tags:
+  - demo-content
+  - simple-post
+  - blog
+---
+
+This post is scheduled for the future, specifically mid-2022. Hopefully you're still blogging by then too. Once that date ticks by, this post will automatically become published and visible.
+
+Otherwise, below is some styled content for you to play with.
+
+A simple post to demonstrate how a normal blog post looks on Hylia. Content is all set in the “Body” field as markdown and Eleventy transforms it into a proper HTML post. You can also edit the markdown file directly if you prefer not to use the CMS.
+
+How about a `<blockquote>`?
+
+> Maecenas faucibus mollis interdum. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Aenean lacinia bibendum nulla sed consectetur. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit libero, a pharetra augue.
+
+A list of stuff:
+
+- Sed posuere consectetur est at lobortis
+- Aenean lacinia bibendum nulla sed consectetur
+- Sed posuere consectetur est at lobortis
+
+How about an ordered list of stuff:
+
+1. Sed posuere consectetur est at lobortis
+2. Aenean lacinia bibendum nulla sed consectetur
+3. Sed posuere consectetur est at lobortis
+
+
+Hopefully, this has demonstrated how simple it is to make a nice looking blog with Hylia.


### PR DESCRIPTION
Scheduled posts only require the date to be in the future.

Draft posts can be flagged with `draft: true` in the front matter of the
markdown file, and they will be automatically excluded from the feeds
and website pages.

(sorry, I ignored the [anti-pattern warning](https://cloudup.com/cdhD8grGtcW))