### PR TITLE
Exclude future posts from tag lists

### DIFF
--- a/src/_data/global.js
+++ b/src/_data/global.js
@@ -4,5 +4,6 @@ module.exports = {
       return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
     };
     return `${segment()}-${segment()}-${segment()}`;
-  }
+  },
+  now: Date.now()
 };

--- a/src/_includes/partials/components/post-list.njk
+++ b/src/_includes/partials/components/post-list.njk
@@ -4,14 +4,16 @@
       <h2 class="[ post-list__heading ] [ text-700 md:text-800 ]">{{ postListHeading }}</h2>
       <ol class="[ post-list__items ] [ sf-flow ] [ pad-top-300 ]" reversed>
         {% for item in postListItems %}
-          <li class="post-list__item">
-            <h3 class="font-base leading-tight text-600 weight-mid">
-              <a href="{{ item.url }}" class="post-list__link" rel="bookmark">{{ item.data.title }}</a>
-            </h3>
-            <p class="text-500 gap-top-300 weight-mid">
-              <time datetime="{{ item.date | w3DateFilter }}">{{ item.date | dateFilter }}</time>
-            </p>
-          </li>
+          {% if item.date.getTime() <= global.now %}
+            <li class="post-list__item">
+              <h3 class="font-base leading-tight text-600 weight-mid">
+                <a href="{{ item.url }}" class="post-list__link" rel="bookmark">{{ item.data.title }}</a>
+              </h3>
+              <p class="text-500 gap-top-300 weight-mid">
+                <time datetime="{{ item.date | w3DateFilter }}">{{ item.date | dateFilter }}</time>
+              </p>
+            </li>
+          {% endif %}
         {% endfor %}
       </ol>
     </div>


### PR DESCRIPTION
I'm not very familiar with 11ty just yet. I didn't see an obvious way to manage this via `collections`. Seems we'd need a dynamic hook into how 11ty generates its tag based collections to also filter the date. Maybe another alternative is to capture all the potential tags from the posts collection and overwrite them.

I took a slightly different path that seemed a little more straight forward. I exposed a timestamp as `global.now` that I used to filter the post list within the view.

Please let me know if there is a more appropriate way to solve this within 11ty best practices.

This resolves #52.