### PR TITLE
Fix home page deploy link

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -7,4 +7,4 @@ socialImage: ''
 ---
 Hylia is a lightweight [Eleventy](https://11ty.io) starter kit with [Netlify CMS](https://www.netlifycms.org/) pre-configured, so that you can one-click install a progressive, accessible blog in minutes. It also gives you a well organised starting point to extend yourself.
 
-Get started now by [deploying Hylia to Netlify.](https://app.netlify.com/start/deploy?repository=https://github.com/andybelldesign/hylia)
+Get started now by [deploying Hylia to Netlify.](https://app.netlify.com/start/deploy?repository=https://github.com/andybelldesign/hylia&stack=cms)


### PR DESCRIPTION
Missed this one when I updated the links in the readme. Sets up Netlify Identity and Git Gateway automatically 👍 