### PR TITLE
fix: footer h2 text color for light/dark themes

### DIFF
--- a/src/scss/components/_post.scss
+++ b/src/scss/components/_post.scss
@@ -126,7 +126,7 @@
     h2 {
       flex-shrink: 0;
       margin-right: get-size('base');
-      color: var(--color-dark);
+      color: var(--color-text);
     }
 
     h2 a {


### PR DESCRIPTION
This h2 "disappears" when using the dark theme, as the text color is the same as the background. Changing `--color-dark` to `--color-text` seems to toggle its text color correctly!